### PR TITLE
Update copyright year for 2021

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
     <div class="container">
       <div class="row">
         <div class="column col-6 t-left">
-          <p>2020 &copy; Andy Sharp &amp; Sons Painting &amp; Decorating Services</p>
+          <p>2021 &copy; Andy Sharp &amp; Sons Painting &amp; Decorating Services</p>
         </div>
         <div class="column col-6 t-right c-grey">
           <p>Website by <a href="https://kerrisharp.com" target="_blank" class="c-grey">Kerri Sharp</a></p>


### PR DESCRIPTION
Very simple PR - updates the copyright year quoted in the footer:

![image](https://user-images.githubusercontent.com/10532380/105522131-c43baf00-5cd4-11eb-87e7-176ec916544b.png)
